### PR TITLE
fix: handling scoped package names

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -24,7 +24,7 @@ export function tryFindDeclarationByName(sourceFile: ts.SourceFile, name: ts.Ent
 
 export function formatName(name: string, upper?: boolean) {
   name = name
-    .replace(/[\/\\._-][a-z]/gi, s => s.substring(1).toUpperCase())
+    .replace(/[\/\\.\@_-][a-z]/gi, s => s.substring(1).toUpperCase())
     .replace(/\/|\\|\./g, '');
   return upper
     ? (name[0].toUpperCase() + name.substring(1))

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -1,0 +1,16 @@
+import { formatName } from '../dist/util';
+
+describe('util.test.ts', () => {
+  describe.only('formatName', () => {
+    it('should format normal package names properly', () => {
+      expect(formatName('JS2DTS')).toEqual('JS2DTS');
+      expect(formatName('js2dts')).toEqual('js2dts');
+      expect(formatName('did-util')).toEqual('didUtil');
+    });
+
+    it('should format scoped package names properly', () => {
+      expect(formatName('@xmark/core')).toEqual('XmarkCore');
+      expect(formatName('@xmark/transform-landing-page')).toEqual('XmarkTransformLandingPage');
+    });
+  });
+});

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -1,7 +1,7 @@
 import { formatName } from '../dist/util';
 
 describe('util.test.ts', () => {
-  describe.only('formatName', () => {
+  describe('formatName', () => {
     it('should format normal package names properly', () => {
       expect(formatName('JS2DTS')).toEqual('JS2DTS');
       expect(formatName('js2dts')).toEqual('js2dts');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

`util.formatName`


##### Description of change

util.formatName is not handling scoped package names properly, that may cause invalid syntax in generated dts file, such as:

```
declare namespace _@arcblockForgeMessage {
  export interface T100 {
    value: any;
    minus: boolean;
  }
  export interface T101 {
    formatMessage: typeof formatMessage;
    createMessage: typeof createMessage;
    fakeMessage: typeof fakeMessage;
    decodeAny: typeof decodeAny;
    encodeAny: typeof encodeAny;
    encodeTimestamp: typeof encodeTimestamp;
    decodeTimestamp: typeof decodeTimestamp;
    encodeBigInt: typeof encodeBigInt;
    decodeBigInt: typeof decodeBigInt;
    attachFormatFn: typeof attachFormatFn;
    attachExampleFn: typeof attachExampleFn;
  }
}
export = _@arcblockForgeMessage;
```
